### PR TITLE
Added 1.16_combat-6.json into net.fabricmc.intermediary to work prope…

### DIFF
--- a/net.fabricmc.intermediary/1.16_combat-6.json
+++ b/net.fabricmc.intermediary/1.16_combat-6.json
@@ -1,0 +1,22 @@
+{
+    "formatVersion": 1,
+    "libraries": [
+        {
+            "name": "net.fabricmc:intermediary:1.16_combat-6",
+            "url": "https://maven.combatreforged.com/"
+        }
+    ],
+    "name": "Intermediary Mappings",
+    "order": 11,
+    "releaseTime": "2021-11-20T05:54:29+0100",
+    "requires": [
+        {
+            "equals": "1.16_combat-6",
+            "uid": "net.minecraft"
+        }
+    ],
+    "type": "release",
+    "uid": "net.fabricmc.intermediary",
+    "version": "1.16_combat-6",
+    "volatile": true
+}


### PR DESCRIPTION
…rly with 1.16_combat-6

Currently, Fabric for latest version of Minecraft 1.1x_combat-x (1.16_combat-6) is being selfhosted by @rizecookey that created special Fabric Intermediary version that works with 1.16_combat-6. Not official, but it works much better.

Signed-off-by: Daniil "latteru" Cherkovskii <110296162+latteru@users.noreply.github.com>